### PR TITLE
Fix TypeError in linear_evaluation.py

### DIFF
--- a/linear_evaluation.py
+++ b/linear_evaluation.py
@@ -167,7 +167,7 @@ if __name__ == "__main__":
     n_features = encoder.fc.in_features  # get dimensions of fc layer
 
     # load pre-trained model from checkpoint
-    simclr_model = SimCLR(args, encoder, n_features)
+    simclr_model = SimCLR(encoder, args.projection_dim, n_features)
     model_fp = os.path.join(args.model_path, "checkpoint_{}.tar".format(args.epoch_num))
     simclr_model.load_state_dict(torch.load(model_fp, map_location=args.device.type))
     simclr_model = simclr_model.to(args.device)


### PR DESCRIPTION
This is a quick fix that gets rid of the `TypeError` mentioned in #28 when running `linear_evaluation.py`. I tested the new code on the given starter command

```
python linear_evaluation.py --dataset=STL10 --model_path=. --epoch_num=100 --resnet resnet50
```

and got final results

```
[FINAL]	 Loss: 0.5152334782385057	 Accuracy: 0.8273689516129032
```

which seem to match up with the results given in the `README`. Let me know if there's anything else I should add/modify, and thanks so much for providing this repo for us!