### PR TITLE
Fix mask issue in distributed nt_xent loss

### DIFF
--- a/simclr/modules/nt_xent.py
+++ b/simclr/modules/nt_xent.py
@@ -31,9 +31,10 @@ class NT_Xent(nn.Module):
         """
         N = 2 * self.batch_size * self.world_size
 
-        z = torch.cat((z_i, z_j), dim=0)
         if self.world_size > 1:
-            z = torch.cat(GatherLayer.apply(z), dim=0)
+            z_i = torch.cat(GatherLayer.apply(z_i), dim=0)
+            z_j = torch.cat(GatherLayer.apply(z_j), dim=0)
+        z = torch.cat((z_i, z_j), dim=0)
 
         sim = self.similarity_f(z.unsqueeze(1), z.unsqueeze(0)) / self.temperature
 


### PR DESCRIPTION
Fix the mask  issue #30  in nt_xent loss when training in a distributed situation. The `all_gather` result of `z` used to build mask should be something like `[z_i1, z_i2, ..., z_iw, z_j1, z_j2, ..., z_jw]` instead of `[z_i1, z_j1,z_i2, z_j2, ..., z_iw, z_jw]`, where `w` represents the `world_size`.